### PR TITLE
renaming this package name to jquery-timepicker for gemfury

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "timepicker",
+	"name": "jquery-timepicker",
 	"version": "1.8.11",
 	"title": "jquery-timepicker",
 	"author": {


### PR DESCRIPTION
It seems that gemfury needs the full name jquery-timepicker in the name field to get the package to be listed as jquery-timepicker